### PR TITLE
SensorNotRequired

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <!-- ionic/angularjs js -->
     <script src="lib/ionic/js/ionic.bundle.js"></script>
 
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB16sGmIekuGIvYOfNoW9T44377IU2d2Es&sensor=true"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB16sGmIekuGIvYOfNoW9T44377IU2d2Es"></script>
 
     <!-- cordova script (this will be a 404 during development) -->
     <script src="cordova.js"></script>


### PR DESCRIPTION
The sensor parameter is no longer required for the Google Maps JavaScript API. It won't prevent the Google Maps JavaScript API from working correctly, but we recommend that you remove the sensor parameter from the script element. 

https://developers.google.com/maps/documentation/javascript/error-messages
